### PR TITLE
Change `defaultRetentionPolicy` to `autogen` to work against influxdb v1.0 for new databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules/
 /statsd-config.js
+/.idea
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 StatsD InfluxDB backend - CHANGELOG
 -----------------------------------
 
+## v0.8.0 (2016-10-01)
+
+* Modified `defaultRetentionPolicy` to work with new databases created in influxDb v1.0
+
 ## v0.6.0 (2015-06-23)
 
 * Initial InfluxDB 0.9 API support (#14, #17)

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -56,7 +56,7 @@ function InfluxdbBackend (startupTime, config, events) {
   self.defaultProxySuffix = 'raw'
   self.defaultProxyFlushInterval = 1000
 
-  self.defaultRetentionPolicy = 'default' // add retention Policy
+  self.defaultRetentionPolicy = 'autogen' // add retention Policy
 
   self.host = self.defaultHost
   self.port = self.defaultPort

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-influxdb-backend",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "InfluxDB backend for StatsD",
   "main": "lib/influxdb.js",
   "dependencies": {},


### PR DESCRIPTION
`Minor` breaking change in influxdb 1.0 means that new dbs are created with a retention policy of `autogen` instead of `default`.

https://github.com/influxdata/influxdb/issues/3733 

`defaultRetentionPolicy` has been changed to `autogen`. This is a breaking change and anyone upgrading to this version must explicitly set the `retentionPolicy: 'default' in their config.js for statsd if they have db's in influxdb created prior to v1.0 (where the default retention policy is in fact`default`.)

Hopefully this makes sense, there are far too many things with the word default in!
Also bumped version to 0.8.0 (semantic version major bump)
Updated CHANGELOG.md
